### PR TITLE
fix: fix CoW in Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,4 +200,5 @@ Cargo.lock
 @reflink
 
 sandbox
+__reflink-tests-*
 *.json.bak

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.0.0"
 crate-type = ["cdylib"]
 
 [dependencies]
+copy_on_write = "0.1.0"
 futures = "0.3.28"
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.12.2", default-features = false, features = ["napi4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.0.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-copy_on_write = "0.1.0"
+copy_on_write = "0.1.1"
 futures = "0.3.28"
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.12.2", default-features = false, features = ["napi4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ futures = "0.3.28"
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.12.2", default-features = false, features = ["napi4"] }
 napi-derive = "2.12.2"
-reflink-copy = { version = "0.1.10" }
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/__test__/threads.spec.ts
+++ b/__test__/threads.spec.ts
@@ -25,7 +25,7 @@ describe('reflink worker', () => {
       content: readFileSync(join(process.cwd(), 'fixtures', 'ascii-file.js')),
     };
 
-    const destFiles = Array.from({ length: 100 }, () => ({
+    const destFiles = Array.from({ length: 1000 }, () => ({
       path: join(TEST_DIR, `dest-${randomUUID()}.js`),
     }));
 
@@ -65,7 +65,7 @@ describe('reflink worker', () => {
     }
   });
 
-  it('clone the same file to different location simultaneously (sync)', async () => {
+  it('clone the same file to different location simultaneously (async)', async () => {
     const src = {
       path: join(process.cwd(), 'fixtures', 'ascii-file.js'),
       content: readFileSync(join(process.cwd(), 'fixtures', 'ascii-file.js')),

--- a/__test__/threads.spec.ts
+++ b/__test__/threads.spec.ts
@@ -25,7 +25,7 @@ describe('reflink worker', () => {
       content: readFileSync(join(process.cwd(), 'fixtures', 'ascii-file.js')),
     };
 
-    const destFiles = Array.from({ length: 1000 }, () => ({
+    const destFiles = Array.from({ length: 100 }, () => ({
       path: join(TEST_DIR, `dest-${randomUUID()}.js`),
     }));
 

--- a/infinite_clone_test.mjs
+++ b/infinite_clone_test.mjs
@@ -31,7 +31,6 @@ async function main() {
     for (let i = 0; i < 1000; i++) {
       const destPath = path.join('./sandbox', `file1-copy-${i}.txt`);
 
-      // Assume reflinkFile is your function that performs the file cloning operation
       await reflinkFile(srcFile.path, destPath);
 
       const destContent = await fs.readFile(destPath, 'utf-8');

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish -t npm",
-    "pretest": "yarn build",
+    "pretest": "pnpm build",
     "test": "cargo t && vitest",
     "bench": "node benchmark.mjs",
     "universal": "napi universal",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,94 +7,90 @@ use napi::{bindgen_prelude::AsyncTask, Env, Error, JsNumber, Result, Task};
 use std::path::PathBuf;
 
 pub struct AsyncReflink {
-  src: PathBuf,
-  dst: PathBuf,
+    src: PathBuf,
+    dst: PathBuf,
 }
 
 #[napi]
 impl Task for AsyncReflink {
-  type Output = ();
-  type JsValue = JsNumber;
+    type Output = ();
+    type JsValue = JsNumber;
 
-  fn compute(&mut self) -> Result<Self::Output> {
-    // Convert PathBuf to &str
-    let src_str = self
-      .src
-      .to_str()
-      .ok_or_else(|| Error::from_reason("Invalid UTF-8 sequence in source path".to_string()))?;
-    let dst_str = self.dst.to_str().ok_or_else(|| {
-      Error::from_reason("Invalid UTF-8 sequence in destination path".to_string())
-    })?;
+    fn compute(&mut self) -> Result<Self::Output> {
+        let src_str = self.src.to_str().ok_or_else(|| {
+          Error::from_reason("Invalid UTF-8 sequence in source path".to_string())
+        })?;
 
-    // Call reflink with string slices
-    match reflink(src_str, dst_str) {
-      Ok(_) => Ok(()),
-      Err(err) => Err(Error::from_reason(format!(
-        "{}, reflink '{}' -> '{}'",
-        err.to_string(),
-        src_str,
-        dst_str
-      ))),
+        let dst_str = self.dst.to_str().ok_or_else(|| {
+          Error::from_reason("Invalid UTF-8 sequence in destination path".to_string())
+        })?;
+
+        match reflink(src_str, dst_str) {
+            Ok(_) => {
+                Ok(())
+            },
+            Err(err) => return Err(Error::from_reason(format!(
+                "{}, reflink '{}' -> '{}'",
+                err.to_string(),
+                self.src.display(),
+                self.dst.display()
+            ))),
+        }
     }
-  }
 
-  fn resolve(&mut self, env: Env, _: ()) -> Result<Self::JsValue> {
-    env.create_int32(0)
-  }
+    fn resolve(&mut self, env: Env, _: ()) -> Result<Self::JsValue> {
+        env.create_int32(0)
+    }
 }
 
 // Async version
 #[napi(js_name = "reflinkFile")]
 pub fn reflink_task(src: String, dst: String) -> AsyncTask<AsyncReflink> {
-  let src_path = PathBuf::from(src);
-  let dst_path = PathBuf::from(dst);
-  AsyncTask::new(AsyncReflink {
-    src: src_path,
-    dst: dst_path,
-  })
+    let src_path = PathBuf::from(src);
+    let dst_path = PathBuf::from(dst);
+    AsyncTask::new(AsyncReflink { src: src_path, dst: dst_path })
 }
 
 // Sync version
 #[napi(js_name = "reflinkFileSync")]
 pub fn reflink_sync(env: Env, src: String, dst: String) -> Result<JsNumber> {
-  // Call reflink with string slices
-  match reflink(&src, &dst) {
-    Ok(_) => Ok(env.create_int32(0)?),
-    Err(err) => Err(Error::from_reason(format!(
-      "{}, reflink '{}' -> '{}'",
-      err.to_string(),
-      src,
-      dst
-    ))),
-  }
+    match reflink(&src, &dst) {
+        Ok(_) => Ok(env.create_int32(0)?),
+        Err(err) => Err(Error::from_reason(format!(
+            "{}, reflink '{}' -> '{}'",
+            err.to_string(),
+            src,
+            dst
+        ))),
+    }
 }
 
 #[test]
 pub fn test_pyc_file() {
-  let src = "fixtures/sample.pyc";
-  let dst = "fixtures/sample.pyc.reflink";
+    let src = "fixtures/sample.pyc";
+    let dst = "fixtures/sample.pyc.reflink";
 
-  let dst_path = std::path::Path::new(dst);
+    let dst_path = std::path::Path::new(dst);
 
-  // Remove the destination file if it already exists
-  if dst_path.exists() {
-    std::fs::remove_file(&dst_path).unwrap();
-  }
+    // Remove the destination file if it already exists
+    if dst_path.exists() {
+        std::fs::remove_file(&dst).unwrap();
+    }
 
-  // Run the reflink operation
-  let result = reflink(src, dst);
-  assert!(result.is_ok());
+    // Run the reflink operation
+    let result = reflink(&src, &dst);
+    assert!(result.is_ok());
 
-  println!("Reflinked '{}' -> '{}'", src, dst);
+    println!("Reflinked '{}' -> '{}'", src, dst);
 
-  // Further validation: compare the contents of both files to make sure they are identical
-  let src_contents = std::fs::read(src).expect("Failed to read source file");
-  let dst_contents = std::fs::read(dst).expect("Failed to read destination file");
+    // Further validation: compare the contents of both files to make sure they are identical
+    let src_contents = std::fs::read(&src).expect("Failed to read source file");
+    let dst_contents = std::fs::read(&dst).expect("Failed to read destination file");
 
-  assert_eq!(src_contents, dst_contents);
+    assert_eq!(src_contents, dst_contents);
 
-  // Remove the destination file
-  std::fs::remove_file(&dst_path).unwrap();
+    // Remove the destination file
+    std::fs::remove_file(&dst).unwrap();
 
-  println!("File contents match, reflink operation successful")
+    println!("File contents match, reflink operation successful")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,10 @@
 extern crate napi_derive;
 use copy_on_write::reflink_file_sync;
 use napi::{bindgen_prelude::AsyncTask, Env, Error, JsNumber, Result, Task};
-use std::path::PathBuf;
 
 pub struct AsyncReflink {
-    src: PathBuf,
-    dst: PathBuf,
+    src: String,
+    dst: String,
 }
 
 #[napi]
@@ -17,23 +16,15 @@ impl Task for AsyncReflink {
     type JsValue = JsNumber;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        let src_str = self.src.to_str().ok_or_else(|| {
-          Error::from_reason("Invalid UTF-8 sequence in source path".to_string())
-        })?;
-
-        let dst_str = self.dst.to_str().ok_or_else(|| {
-          Error::from_reason("Invalid UTF-8 sequence in destination path".to_string())
-        })?;
-
-        match reflink_file_sync(src_str, dst_str) {
+        match reflink_file_sync(&self.src, &self.dst) {
             Ok(_) => {
                 Ok(())
             },
             Err(err) => return Err(Error::from_reason(format!(
                 "{}, reflink '{}' -> '{}'",
                 err.to_string(),
-                self.src.display(),
-                self.dst.display()
+                self.src,
+                self.dst
             ))),
         }
     }
@@ -46,15 +37,13 @@ impl Task for AsyncReflink {
 // Async version
 #[napi(js_name = "reflinkFile")]
 pub fn reflink_task(src: String, dst: String) -> AsyncTask<AsyncReflink> {
-    let src_path = PathBuf::from(src);
-    let dst_path = PathBuf::from(dst);
-    AsyncTask::new(AsyncReflink { src: src_path, dst: dst_path })
+    AsyncTask::new(AsyncReflink { src, dst })
 }
 
 // Sync version
 #[napi(js_name = "reflinkFileSync")]
 pub fn reflink_sync(env: Env, src: String, dst: String) -> Result<JsNumber> {
-    match reflink_file_sync(src, dst) {
+    match reflink_file_sync(&src, &dst) {
         Ok(_) => Ok(env.create_int32(0)?),
         Err(err) => Err(Error::from_reason(format!(
             "{}, reflink '{}' -> '{}'",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,88 +2,99 @@
 
 #[macro_use]
 extern crate napi_derive;
-
+use copy_on_write::reflink_file_sync as reflink;
 use napi::{bindgen_prelude::AsyncTask, Env, Error, JsNumber, Result, Task};
 use std::path::PathBuf;
-use reflink_copy;
 
 pub struct AsyncReflink {
-    src: PathBuf,
-    dst: PathBuf,
+  src: PathBuf,
+  dst: PathBuf,
 }
 
 #[napi]
 impl Task for AsyncReflink {
-    type Output = ();
-    type JsValue = JsNumber;
+  type Output = ();
+  type JsValue = JsNumber;
 
-    fn compute(&mut self) -> Result<Self::Output> {
-        match reflink_copy::reflink(&self.src, &self.dst) {
-            Ok(_) => {
-                Ok(())
-            },
-            Err(err) => return Err(Error::from_reason(format!(
-                "{}, reflink '{}' -> '{}'",
-                err.to_string(),
-                self.src.display(),
-                self.dst.display()
-            ))),
-        }
-    }
+  fn compute(&mut self) -> Result<Self::Output> {
+    // Convert PathBuf to &str
+    let src_str = self
+      .src
+      .to_str()
+      .ok_or_else(|| Error::from_reason("Invalid UTF-8 sequence in source path".to_string()))?;
+    let dst_str = self.dst.to_str().ok_or_else(|| {
+      Error::from_reason("Invalid UTF-8 sequence in destination path".to_string())
+    })?;
 
-    fn resolve(&mut self, env: Env, _: ()) -> Result<Self::JsValue> {
-        env.create_int32(0)
+    // Call reflink with string slices
+    match reflink(src_str, dst_str) {
+      Ok(_) => Ok(()),
+      Err(err) => Err(Error::from_reason(format!(
+        "{}, reflink '{}' -> '{}'",
+        err.to_string(),
+        src_str,
+        dst_str
+      ))),
     }
+  }
+
+  fn resolve(&mut self, env: Env, _: ()) -> Result<Self::JsValue> {
+    env.create_int32(0)
+  }
 }
 
 // Async version
 #[napi(js_name = "reflinkFile")]
 pub fn reflink_task(src: String, dst: String) -> AsyncTask<AsyncReflink> {
-    let src_path = PathBuf::from(src);
-    let dst_path = PathBuf::from(dst);
-    AsyncTask::new(AsyncReflink { src: src_path, dst: dst_path })
+  let src_path = PathBuf::from(src);
+  let dst_path = PathBuf::from(dst);
+  AsyncTask::new(AsyncReflink {
+    src: src_path,
+    dst: dst_path,
+  })
 }
 
 // Sync version
 #[napi(js_name = "reflinkFileSync")]
 pub fn reflink_sync(env: Env, src: String, dst: String) -> Result<JsNumber> {
-    let src_path = PathBuf::from(src);
-    let dst_path = PathBuf::from(dst);
-    match reflink_copy::reflink(&src_path, &dst_path) {
-        Ok(_) => Ok(env.create_int32(0)?),
-        Err(err) => Err(Error::from_reason(format!(
-            "{}, reflink '{}' -> '{}'",
-            err.to_string(),
-            src_path.display(),
-            dst_path.display()
-        ))),
-    }
+  // Call reflink with string slices
+  match reflink(&src, &dst) {
+    Ok(_) => Ok(env.create_int32(0)?),
+    Err(err) => Err(Error::from_reason(format!(
+      "{}, reflink '{}' -> '{}'",
+      err.to_string(),
+      src,
+      dst
+    ))),
+  }
 }
 
 #[test]
 pub fn test_pyc_file() {
-    let src = std::path::Path::new("fixtures/sample.pyc");
-    let dst = std::path::Path::new("fixtures/sample.pyc.reflink");
+  let src = "fixtures/sample.pyc";
+  let dst = "fixtures/sample.pyc.reflink";
 
-    // Remove the destination file if it already exists
-    if dst.exists() {
-        std::fs::remove_file(&dst).unwrap();
-    }
+  let dst_path = std::path::Path::new(dst);
 
-    // Run the reflink operation
-    let result = reflink_copy::reflink(&src, &dst);
-    assert!(result.is_ok());
+  // Remove the destination file if it already exists
+  if dst_path.exists() {
+    std::fs::remove_file(&dst_path).unwrap();
+  }
 
-    println!("Reflinked '{}' -> '{}'", src.display(), dst.display());
+  // Run the reflink operation
+  let result = reflink(src, dst);
+  assert!(result.is_ok());
 
-    // Further validation: compare the contents of both files to make sure they are identical
-    let src_contents = std::fs::read(&src).expect("Failed to read source file");
-    let dst_contents = std::fs::read(&dst).expect("Failed to read destination file");
+  println!("Reflinked '{}' -> '{}'", src, dst);
 
-    assert_eq!(src_contents, dst_contents);
+  // Further validation: compare the contents of both files to make sure they are identical
+  let src_contents = std::fs::read(src).expect("Failed to read source file");
+  let dst_contents = std::fs::read(dst).expect("Failed to read destination file");
 
-    // Remove the destination file
-    std::fs::remove_file(&dst).unwrap();
+  assert_eq!(src_contents, dst_contents);
 
-    println!("File contents match, reflink operation successful")
+  // Remove the destination file
+  std::fs::remove_file(&dst_path).unwrap();
+
+  println!("File contents match, reflink operation successful")
 }


### PR DESCRIPTION
Closes https://github.com/pnpm/pnpm/issues/7186

---

This PR changes the package to create the reflinks from `reflink-copy` to `copy_on_write`, on Unix it is still using `reflink-copy` underneath.

In the `copy_on_write` package I have fixed a bug that occurred in ReFS file systems where if you clone the same file to different destinations at the same time (multi-threading basically), the source was modified and filled with null bytes.

The solution to this error is to open the source with the `FILE_FLAG_NO_BUFFERING` flag (https://github.com/microsoft/CopyOnWrite/issues/12#issue-1374819104).

Also, one important thing, in https://github.com/nachoaldamav/CopyOnWrite I created some Github Actions to run the tests in the specific File systems we want to test, using Google Cloud VMs.