### PR TITLE
feat: release canary versions from PRs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -402,17 +402,24 @@ jobs:
       - name: Publish
         run: |
           npm config set provenance true
-          if git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$";
-          then
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          if [ "${GITHUB_REF##*/}" = "main" ]; then
+            if git log -1 --pretty=%B | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$"; then
+              echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+              pnpm publish --access public
+            elif git log -1 --pretty=%B | grep -E "^[0-9]+\.[0-9]+\.[0-9]+"; then
+              echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+              pnpm publish --tag next --access public
+            else
+              echo "Not a release, skipping publish"
+            fi
+          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            jq --arg hash "$COMMIT_HASH" '.version = $hash' package.json > temp.json && mv temp.json package.json
+            pnpm run version
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            pnpm publish --access public
-          elif git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+";
-          then
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            pnpm publish --tag next --access public
-          else
-            echo "Not a release, skipping publish"
+            pnpm publish --tag canary --access public
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -414,10 +414,14 @@ jobs:
               echo "Not a release, skipping publish"
             fi
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            jq --arg hash "$COMMIT_HASH" '.version = $hash' package.json > temp.json && mv temp.json package.json
-            pnpm run version
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            pnpm publish --tag canary --access public
+            if git log -1 --pretty=%B | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$"; then
+              jq --arg hash "$COMMIT_HASH" '.version = $hash' package.json > temp.json && mv temp.json package.json
+              pnpm run version
+              echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+              pnpm publish --tag canary --access public --no-git-checks
+            else
+              echo "Not a release, skipping publish"
+            fi
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -403,27 +403,35 @@ jobs:
         run: |
           npm config set provenance true
           COMMIT_HASH=$(git rev-parse --short HEAD)
+          COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+          RELEASE_TYPE=$(echo $COMMIT_MESSAGE | grep -oE "^release \(([a-zA-Z]+)\): [0-9]+\.[0-9]+\.[0-9]+$" | grep -oE "\(([a-zA-Z]+)\)" | tr -d '()')
+      
           if [ "${GITHUB_REF##*/}" = "main" ]; then
-            if git log -1 --pretty=%B | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$"; then
+            if [[ $COMMIT_MESSAGE == release* ]]; then
+              # Use a default release type of 'latest' if no type is specified in the commit message
+              RELEASE_TYPE=${RELEASE_TYPE:-latest}
               echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-              pnpm publish --access public
-            elif git log -1 --pretty=%B | grep -E "^[0-9]+\.[0-9]+\.[0-9]+"; then
-              echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-              pnpm publish --tag next --access public
+              pnpm publish --tag $RELEASE_TYPE --access public
             else
-              echo "Not a release, skipping publish"
+              echo "Commit does not start with 'release', skipping publish"
             fi
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            if git log -1 --pretty=%B | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$"; then
+            if [[ $COMMIT_MESSAGE == release* ]]; then
+              # Use a default release type of 'canary' if no type is specified in the commit message
+              RELEASE_TYPE=${RELEASE_TYPE:-canary}
               jq --arg hash "$COMMIT_HASH" '.version = $hash' package.json > temp.json && mv temp.json package.json
               pnpm run version
               echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-              pnpm publish --tag canary --access public --no-git-checks
+              pnpm publish --tag $RELEASE_TYPE --access public --no-git-checks
             else
-              echo "Not a release, skipping publish"
+              echo "PR does not start with 'release', skipping publish"
             fi
+          else
+            echo "Not a release, skipping publish"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      
+      
       


### PR DESCRIPTION
With this change, if a PR has a commit like `release: v1.0.0`, the action will publish the commit as a canary version to npm, using the commit hash as the version. If it's a commit to main or a merge, it will release it as latest.